### PR TITLE
fix: prevent TTS double-play race in reading passages

### DIFF
--- a/app/practice/[sessionId].tsx
+++ b/app/practice/[sessionId].tsx
@@ -63,6 +63,7 @@ export default function PracticeSessionScreen() {
     cancel: cancelPassage,
   } = useStreamedPassage(session?.level, Number(sessionId));
   const sessionRef = useRef(session);
+  const speechBusyRef = useRef(false);
 
   const { index: activeSpeechIndex, phase: activeSpeechPhase } = speechState;
 
@@ -112,7 +113,10 @@ export default function PracticeSessionScreen() {
       }
     }
 
+    if (speechBusyRef.current) return;
+
     try {
+      speechBusyRef.current = true;
       setSpeechState({ index, phase: "loading" });
       await ai.generateSpeech(text);
       setSpeechState((current) => {
@@ -124,6 +128,8 @@ export default function PracticeSessionScreen() {
       console.error("Speech generation failed:", error);
       Alert.alert("Error", "Failed to play paragraph");
       setSpeechState({ index: null, phase: "idle" });
+    } finally {
+      speechBusyRef.current = false;
     }
   };
 

--- a/services/request.ts
+++ b/services/request.ts
@@ -61,6 +61,8 @@ export async function getAiExamples(
   return resp.json() as Promise<AiExample[]>;
 }
 
+const inFlightTtsDownloads = new Map<string, Promise<File>>();
+
 /**
  * Get audio file for text-to-speech synthesis.
  * @param {string} prompt - Text to synthesize
@@ -89,6 +91,13 @@ export async function getAiSound(
   const cacheKey = hashCacheKey(`${prompt}|${voice ?? ""}|${lang ?? ""}`);
   const targetFile = new File(Paths.cache, `tts_${cacheKey}.mp3`);
 
+  // Dedupe concurrent requests for the same audio so two near-simultaneous
+  // plays don't race on the same destination ("Destination already exists").
+  const inFlight = inFlightTtsDownloads.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
   if (targetFile.exists) {
     return targetFile;
   }
@@ -99,20 +108,29 @@ export async function getAiSound(
   if (voice) queryParams.append("voice", voice);
   if (lang) queryParams.append("lang", lang);
 
-  const file = await File.downloadFileAsync(
-    `${process.env.EXPO_PUBLIC_BASE_URL}/sound?${queryParams.toString()}`,
-    targetFile,
-    {
-      headers,
-      idempotent: false,
+  const download = (async () => {
+    const file = await File.downloadFileAsync(
+      `${process.env.EXPO_PUBLIC_BASE_URL}/sound?${queryParams.toString()}`,
+      targetFile,
+      {
+        headers,
+        idempotent: false,
+      }
+    );
+
+    if (!file.exists) {
+      throw new Error("Failed to download audio" + file.uri);
     }
-  );
 
-  if (!file.exists) {
-    throw new Error("Failed to download audio" + file.uri);
+    return file;
+  })();
+
+  inFlightTtsDownloads.set(cacheKey, download);
+  try {
+    return await download;
+  } finally {
+    inFlightTtsDownloads.delete(cacheKey);
   }
-
-  return file;
 }
 
 function hashCacheKey(input: string): string {


### PR DESCRIPTION
A fast double-press on a passage paragraph's play button fired two concurrent getAiSound downloads to the same cache file, so File.downloadFileAsync threw "Destination already exists" and the app fell back to expo-speech.

- handlePlayParagraph: a synchronous speechBusyRef guard blocks re-entry while a play is loading (prevents the duplicate call and double playback); pause/resume/stop toggles are unaffected
- getAiSound: dedupe concurrent downloads via an in-flight promise map, checked before the file-exists check so a mid-download partial file is never returned